### PR TITLE
MqttSubscriptionClient: connection lost (https://github.com/awslabs/aws-mobile-appsync-sdk-android/issues/22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## AWS AppSync SDK for Android
 [![GitHub release](https://img.shields.io/github/release/awslabs/aws-mobile-appsync-sdk-android.svg)](https://github.com/awslabs/aws-mobile-appsync-sdk-android/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.amazonaws/aws-android-sdk-appsync.svg)]()
+[![Build Status](https://travis-ci.org/awslabs/aws-mobile-appsync-sdk-android.svg?branch=master)](https://travis-ci.org/awslabs/aws-mobile-appsync-sdk-android)
 
 The AWS AppSync SDK for Android enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations`, and `Subscriptions`. The SDK also includes support for offline operations. This SDK is based off of the Apollo project found [here](https://github.com/apollographql/apollo-android).
 

--- a/aws-android-sdk-appsync/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncQueryInstrumentationTest.java
+++ b/aws-android-sdk-appsync/src/androidTest/java/com/amazonaws/mobileconnectors/appsync/AWSAppSyncQueryInstrumentationTest.java
@@ -244,7 +244,7 @@ public class AWSAppSyncQueryInstrumentationTest {
         assertTrue( postID.equals(deletePostMutationResponse.data().deletePost().id()));
 
         //Check that it is gone from the server
-        queryPost(AppSyncResponseFetchers.NETWORK_FIRST, postID);
+        queryPost(AppSyncResponseFetchers.NETWORK_ONLY, postID);
         assertNotNull(getPostQueryResponse);
         assertNotNull(getPostQueryResponse.data());
         assertNull(getPostQueryResponse.data().getPost());


### PR DESCRIPTION
*Issue #22: MqttSubscriptionClient: connection lost*

*Description of changes:*
Added creation of `HashSet` with subscription objects just before iteration in `onError()` callback in `subscribe()` method. 
As iteration over `getSubscriptionObjects()` result is not synchronized with other methods that can change` subscriptionsByTopic` field value, modification of topic subscribers while `onError()` callback is in progress can cause `ConcurrentModificationException`.  As subscriber (`SubscriptionObject`), for whom `onError()` should trigger `onFailure()` on listeners, already has been added to the set, the simplest way is to create copy of `getSubscriptionObjects()` result and iterate over it.
I tried to use 1.1.0 version of `org.eclipse.paho:org.eclipse.paho.client.mqttv3` with the latest versions of other libraries as suggested in the issue comments, but in this case subscription called `OnCompleted()` right after it had been started and didn't send any successfull responses. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
